### PR TITLE
redirected the files for unity

### DIFF
--- a/resource-alice/Makefile
+++ b/resource-alice/Makefile
@@ -101,7 +101,7 @@ endif
 endif
 
 %/user-alice-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/brennan_2016_fmri' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/brennan_2016_fmri' > $@
 
 ################################################################################
 #

--- a/resource-bmmm/Makefile
+++ b/resource-bmmm/Makefile
@@ -76,7 +76,7 @@ endif
 
 
 %/user-bmmm-directory.txt: | %
-	echo '/project/lin-dept/compling/bmmm' > $@
+	echo '/fs/project/schuler.77/compling/bmmm' > $@
 
 ################################################################################
 #

--- a/resource-bnc/Makefile
+++ b/resource-bnc/Makefile
@@ -81,7 +81,7 @@ endif
 
 
 %/user-bnc-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/bnc' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/bnc' > $@
 
 ################################################################################
 #

--- a/resource-brown/Makefile
+++ b/resource-brown/Makefile
@@ -81,7 +81,7 @@ endif
 endif
 
 %/user-brown-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/SPR_brown' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/SPR_brown' > $@
 
 ################################################################################
 #

--- a/resource-ccl/Makefile
+++ b/resource-ccl/Makefile
@@ -71,7 +71,7 @@ endif
 
 
 %/user-ccl-directory.txt: | %
-	echo '/project/lin-dept/compling/cclparser' > $@
+	echo '/fs/project/schuler.77/compling/cclparser' > $@
 
 ################################################################################
 #

--- a/resource-cdr/Makefile
+++ b/resource-cdr/Makefile
@@ -72,7 +72,7 @@ endif
 
 
 %/user-cdr-directory.txt: | %   
-	echo '/project/lin-dept/compling/cdr' > $@
+	echo '/fs/project/schuler.77/compling/cdr' > $@
 
 ### WS: THIS LINE BREAKS ALL OF PYTHON ON DEASY NOW (2021-08-18)
 #PYTHONPATH= $(shell cat $(CONFIGDIR)/user-cdr-directory.txt)

--- a/resource-chgcg/Makefile
+++ b/resource-chgcg/Makefile
@@ -17,7 +17,7 @@ include $(RESOURCE-LVPCFG)/Makefile
 
 #### location of treebank
 user-treebank-location.txt:
-	echo '/project/lin-dept/corpora/original/chinese/chinese_treebank_6' > $@
+	echo '/fs/project/schuler.77/corpora/original/chinese/chinese_treebank_6' > $@
 	@echo ''
 	@echo 'ATTENTION: I had to create "$@" for you, which may be wrong'
 	@echo 'edit it to point at your treebank repository, and re-run make to continue!'
@@ -25,14 +25,14 @@ user-treebank-location.txt:
 
 #### location of chinese treebank8
 user-treebank8-location.txt:
-	echo '/project/lin-dept/corpora/original/chinese/chinese_treebank_8' > $@
+	echo '/fs/project/schuler.77/corpora/original/chinese/chinese_treebank_8' > $@
 	@echo ''
 	@echo 'ATTENTION: I had to create "$@" for you, which may be wrong'
 	@echo 'edit it to point at your treebank repository, and re-run make to continue!'
 	@echo ''
 
 #edit it to point at your treebank repository
-user-chccgbank-location='/project/lin-dept/corpora/original/chinese/chinese_ccg/final'
+user-chccgbank-location='/fs/project/schuler.77/corpora/original/chinese/chinese_ccg/final'
 
 
 ### using chinese treebank 8

--- a/resource-childes/Makefile
+++ b/resource-childes/Makefile
@@ -75,7 +75,7 @@ endif
 
 
 %/user-childes-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/childes' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/childes' > $@
 
 ################################################################################
 #

--- a/resource-conlen/Makefile
+++ b/resource-conlen/Makefile
@@ -83,7 +83,7 @@ endif
 
 
 %/user-conlen-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/constituent_length' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/constituent_length' > $@
 
 ################################################################################
 #

--- a/resource-conllscorer/Makefile
+++ b/resource-conllscorer/Makefile
@@ -80,7 +80,7 @@ endif
 
 
 %/user-conllscorer-directory.txt: | %
-	echo '/project/lin-dept/compling/reference-coreference-scorers-master' > $@
+	echo '/fs/project/schuler.77/compling/reference-coreference-scorers-master' > $@
     
 ################################################################################
 #

--- a/resource-dmv/Makefile
+++ b/resource-dmv/Makefile
@@ -76,7 +76,7 @@ endif
 
 
 %/user-dmv-directory.txt: | %
-	echo '/project/lin-dept/compling/pr-dep-parsing.WILS' > $@
+	echo '/fs/project/schuler.77/compling/pr-dep-parsing.WILS' > $@
 
 ################################################################################
 #

--- a/resource-dundee/Makefile
+++ b/resource-dundee/Makefile
@@ -93,7 +93,7 @@ endif
 
     
 %/user-dundee-directory.txt: | %
-	echo '/project/lin-dept/corpora/original/english/dundee' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/dundee' > $@
     
 ################################################################################
 #

--- a/resource-epic/Makefile
+++ b/resource-epic/Makefile
@@ -74,7 +74,7 @@ JAVAFLAGS := $(shell cat $(CONFIG))
 endif
 
 %/user-epicjar-directory.txt: | %
-	echo '/project/lin-dept/compling/epic' > $@
+	echo '/fs/project/schuler.77/compling/epic' > $@
 
 EPIC-TRAINER = target/scala-2.11/epic-assembly-0.4.4.jar epic.parser.models.ParserTrainer
 

--- a/resource-fedorenkoetal16ecog/Makefile
+++ b/resource-fedorenkoetal16ecog/Makefile
@@ -90,7 +90,7 @@ endif
 
 
 %/user-fedorenkoetal16ecog-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/fedorenkoetal16_ecog' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/fedorenkoetal16_ecog' > $@
 
 ################################################################################
 #

--- a/resource-forrest/Makefile
+++ b/resource-forrest/Makefile
@@ -80,7 +80,7 @@ endif
 endif
 
 %/user-forrest-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/german/forrest_gump_audio' > $@
+	echo '/fs/project/schuler.77/corpora/original/german/forrest_gump_audio' > $@
 
 ################################################################################
 #

--- a/resource-geco/Makefile
+++ b/resource-geco/Makefile
@@ -82,7 +82,7 @@ endif
 
     
 %/user-geco-directory.txt: | %
-	echo '/project/lin-dept/corpora/original/english/geco' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/geco' > $@
     
 ################################################################################
 #

--- a/resource-gigaword/Makefile
+++ b/resource-gigaword/Makefile
@@ -105,7 +105,7 @@ endif
 
 ## Default version of Gigaword is Gigaword 4, FYI
 %/user-gigaword-directory.txt: | %
-	echo '/project/lin-dept/corpora/original/english/gigaword-4' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/gigaword-4' > $@
 
 %/user-gigaword-sects.txt: | %
 	echo $(GIGA4SECTS) > $@

--- a/resource-glove/Makefile
+++ b/resource-glove/Makefile
@@ -89,7 +89,7 @@ endif
 
 
 %/user-glove-directory.txt: | % 
-	echo '/project/lin-dept/compling/GloVe-1.2/' > $@
+	echo '/fs/project/schuler.77/compling/GloVe-1.2/' > $@
 
 ################################################################################
 #

--- a/resource-glstm/Makefile
+++ b/resource-glstm/Makefile
@@ -43,7 +43,7 @@ endif
 endif
 
 %/user-glstm-directory.txt: | %   
-	echo '/project/lin-dept/compling/glstm' > $@
+	echo '/fs/project/schuler.77/compling/glstm' > $@
 
 ################################################################################
 

--- a/resource-gpt2/Makefile
+++ b/resource-gpt2/Makefile
@@ -42,7 +42,7 @@ endif
 endif
 
 %/user-gpt2-directory.txt: | %
-	echo '/project/lin-dept/compling/gpt2' > $@
+	echo '/fs/project/schuler.77/compling/gpt2' > $@
 
 ################################################################################
 

--- a/resource-hf/Makefile
+++ b/resource-hf/Makefile
@@ -42,7 +42,7 @@ endif
 endif
 
 %/user-hf-directory.txt: | %
-	echo '/project/lin-dept/compling/huggingface' > $@
+	echo '/fs/project/schuler.77/compling/huggingface' > $@
 
 ################################################################################
 

--- a/resource-huth/Makefile
+++ b/resource-huth/Makefile
@@ -71,7 +71,7 @@ endif
 endif
     
 %/user-huth-directory.txt: | %   
-	echo '/project/lin-dept/compling/speechmodeltutorial' > $@
+	echo '/fs/project/schuler.77/compling/speechmodeltutorial' > $@
 
 ################################################################################
 #

--- a/resource-incrsem/Makefile
+++ b/resource-incrsem/Makefile
@@ -110,7 +110,7 @@ scripts/%.ini:  $(INCRSEM-SCRIPTS)/%.ini  |  scripts
 ################################################################################
 
 ## obtain auto-parsed simplewiki corpus...
-%simplewikiFULLAUTO.gcg15.linetrees:  /project/lin-dept/corpora/original/english/simplewiki20140903/simplewiki-20140903-pages-articles.wsj02to21-comparativized-gcg15-4sm.berk.parsed.linetrees
+%simplewikiFULLAUTO.gcg15.linetrees:  /fs/project/schuler.77/corpora/original/english/simplewiki20140903/simplewiki-20140903-pages-articles.wsj02to21-comparativized-gcg15-4sm.berk.parsed.linetrees
 	ln -s $< $@
 
 ## remove % comments

--- a/resource-jlstm/Makefile
+++ b/resource-jlstm/Makefile
@@ -43,7 +43,7 @@ endif
 endif
 
 %/user-jlstm-directory.txt: | %   
-	echo '/project/lin-dept/compling/jlstm' > $@
+	echo '/fs/project/schuler.77/compling/jlstm' > $@
 
 ################################################################################
 

--- a/resource-kenlm/Makefile
+++ b/resource-kenlm/Makefile
@@ -126,10 +126,10 @@ endif
 
 
 %/user-kenlm-directory.txt: | %
-	echo '/project/lin-dept/compling/kenlm_git' > $@
+	echo '/fs/project/schuler.77/compling/kenlm_git' > $@
 
 %/user-kenlm-model-directory.txt: | %
-	echo '/project/lin-dept/compling/kenlm_models' > $@
+	echo '/fs/project/schuler.77/compling/kenlm_models' > $@
 
 %/user-kenlm-flags.txt: | %
 	echo '-T kenlmtmp -S 50%' > $@

--- a/resource-lvpcfg/Makefile
+++ b/resource-lvpcfg/Makefile
@@ -74,7 +74,7 @@ JAVAFLAGS := $(shell cat $(CONFIG))
 endif
 
 %/user-berkeleyparserjar-directory.txt: | %
-	echo '/project/lin-dept/compling/berkeleyparser' > $@
+	echo '/fs/project/schuler.77/compling/berkeleyparser' > $@
 
 %/user-javaflags.txt: | %
 	echo '-Xmx8g' > $@

--- a/resource-naturalstories/Makefile
+++ b/resource-naturalstories/Makefile
@@ -89,7 +89,7 @@ endif
 endif
 
 %/user-naturalstories-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/naturalstories' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/naturalstories' > $@
 
 ################################################################################
 #

--- a/resource-naturalstoriesfmri/Makefile
+++ b/resource-naturalstoriesfmri/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 %/user-naturalstories-fmri-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/naturalstories_fmri' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/naturalstories_fmri' > $@
 
 ################################################################################
 #

--- a/resource-naturalstoriesfmri2/Makefile
+++ b/resource-naturalstoriesfmri2/Makefile
@@ -100,7 +100,7 @@ endif
 endif
 
 %/user-naturalstories-fmri2-directory.txt: | %
-	echo '/project/lin-dept/corpora/original/english/naturalstories_fmri' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/naturalstories_fmri' > $@
 
 
 ################################################################################

--- a/resource-naturalstoriesmaze/Makefile
+++ b/resource-naturalstoriesmaze/Makefile
@@ -81,7 +81,7 @@ endif
 endif
 
 %/user-naturalstoriesmaze-directory.txt: | %
-	echo '/project/lin-dept/corpora/original/english/natural-stories-maze' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/natural-stories-maze' > $@
 
 ################################################################################
 #

--- a/resource-ontonotes/Makefile
+++ b/resource-ontonotes/Makefile
@@ -75,7 +75,7 @@ endif
 
 
 %/user-ontonotes-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/ontonotes5' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/ontonotes5' > $@
 
 ################################################################################
 #

--- a/resource-openwebtext/Makefile
+++ b/resource-openwebtext/Makefile
@@ -70,7 +70,7 @@ endif
 endif
 
 %/user-openwebtext-directory.txt: | %
-	echo '/project/lin-dept/corpora/original/english/openwebtext' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/openwebtext' > $@
 
 ################################################################################
 #

--- a/resource-passages/Makefile
+++ b/resource-passages/Makefile
@@ -113,7 +113,7 @@ endif
 
 
 %/user-passages-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/MITpassages' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/MITpassages' > $@
 
 ################################################################################
 #

--- a/resource-provo/Makefile
+++ b/resource-provo/Makefile
@@ -82,7 +82,7 @@ endif
 
     
 %/user-provo-directory.txt: | %
-	echo '/project/lin-dept/corpora/original/english/provo' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/provo' > $@
     
 ################################################################################
 #

--- a/resource-rhacks/Makefile
+++ b/resource-rhacks/Makefile
@@ -71,7 +71,7 @@ endif
 endif
     
 %/user-rhacks-directory.txt: | %   
-	echo '/project/lin-dept/compling/R-hacks' > $@
+	echo '/fs/project/schuler.77/compling/R-hacks' > $@
 
 ################################################################################
 #

--- a/resource-skipdep/Makefile
+++ b/resource-skipdep/Makefile
@@ -71,7 +71,7 @@ endif
 endif
     
 %/user-skipdep-directory.txt: | %   
-	echo '/project/lin-dept/compling/skipdep' > $@
+	echo '/fs/project/schuler.77/compling/skipdep' > $@
 
 ################################################################################
 #

--- a/resource-srilm/Makefile
+++ b/resource-srilm/Makefile
@@ -84,7 +84,7 @@ endif
 
 
 %/user-srilm-directory.txt: | %
-	echo '/project/lin-dept/compling/srilm/bin/i686-m64' > $@
+	echo '/fs/project/schuler.77/compling/srilm/bin/i686-m64' > $@
 
 ################################################################################
 #

--- a/resource-tiger/Makefile
+++ b/resource-tiger/Makefile
@@ -65,7 +65,7 @@ endif
 
     
 %/user-tiger-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/german/tigercorpus1' > $@
+	echo '/fs/project/schuler.77/corpora/original/german/tigercorpus1' > $@
     
 ################################################################################
 #

--- a/resource-tokenizer/Makefile
+++ b/resource-tokenizer/Makefile
@@ -72,7 +72,7 @@ endif
 
 
 %/user-tokenizer-directory.txt: | %
-	echo '/project/lin-dept/compling/extended_penn_tokenizer' > $@
+	echo '/fs/project/schuler.77/compling/extended_penn_tokenizer' > $@
 
 ################################################################################
 #

--- a/resource-tom/Makefile
+++ b/resource-tom/Makefile
@@ -83,7 +83,7 @@ endif
 
 
 %/user-tom-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/saxe_tom' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/saxe_tom' > $@
 
 ################################################################################
 #

--- a/resource-treebank/Makefile
+++ b/resource-treebank/Makefile
@@ -76,9 +76,9 @@ endif
 
 
 %/user-treebank-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/penn_treebank_3' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/penn_treebank_3' > $@
 %/user-treebank-vadas-directory.txt: | %
-	echo '/project/lin-dept/corpora/original/english/penn_treebank_3_vadas_np_bracketing' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/penn_treebank_3_vadas_np_bracketing' > $@
 
 ################################################################################
 #

--- a/resource-ucl/Makefile
+++ b/resource-ucl/Makefile
@@ -139,13 +139,13 @@ endif
 
 
 %/user-ucl-directory.txt: | %
-	echo '/project/lin-dept/corpora/original/english/ucl_novels' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/ucl_novels' > $@
 
 %/user-esn-directory.txt: | %
-	echo '/project/lin-dept/corpora/original/english/dundee/echo_state' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/dundee/echo_state' > $@
 
 %/user-geniatagger-directory.txt: | %
-	echo '/project/lin-dept/compling/geniatagger-2.0.2' > $@
+	echo '/fs/project/schuler.77/compling/geniatagger-2.0.2' > $@
 
 
 ################################################################################

--- a/resource-upparse/Makefile
+++ b/resource-upparse/Makefile
@@ -74,7 +74,7 @@ endif
 
 
 %/user-upparse-directory.txt: | %
-	echo '/project/lin-dept/compling/upparse' > $@
+	echo '/fs/project/schuler.77/compling/upparse' > $@
 
 ################################################################################
 #

--- a/resource-williams/Makefile
+++ b/resource-williams/Makefile
@@ -83,7 +83,7 @@ endif
 
 
 %/user-williams-directory.txt: | %   
-	echo '/project/lin-dept/corpora/original/english/williams' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/williams' > $@
 
 ################################################################################
 #

--- a/resource-word2vec/Makefile
+++ b/resource-word2vec/Makefile
@@ -78,7 +78,7 @@ endif
 
 
 %/user-word2vec-directory.txt: | % 
-	echo '/project/lin-dept/compling/word2vec/' > $@
+	echo '/fs/project/schuler.77/compling/word2vec/' > $@
 
 ################################################################################
 #

--- a/resource-wordnet/Makefile
+++ b/resource-wordnet/Makefile
@@ -70,7 +70,7 @@ endif
 
 
 %/user-wordnet-directory.txt: | % 
-	echo '/project/lin-dept/corpora/original/english/wordnet-3.1' > $@
+	echo '/fs/project/schuler.77/corpora/original/english/wordnet-3.1' > $@
 
 ################################################################################
 #

--- a/resource-xlsx2csv/Makefile
+++ b/resource-xlsx2csv/Makefile
@@ -71,7 +71,7 @@ endif
 endif
     
 %/user-xlsx2csv-directory.txt: | %   
-	echo '/project/lin-dept/compling/xlsx2csv' > $@
+	echo '/fs/project/schuler.77/compling/xlsx2csv' > $@
 
 ################################################################################
 #


### PR DESCRIPTION
The issue was described by the Question 12 in [COCOMO](https://linguistics.osu.edu/schulerlab/welcome/setting-modelblocks-jobs-unity)

I modified the makefiles to correct the user-...-directory.txt files in the config directory. They should now work properly for unity users.